### PR TITLE
Add GitHub Actions to this lab

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,14 @@
+name: c-tests
+on: [push, pull_request]
+
+jobs:
+  test-project:
+    name: Test Project
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Test project with googletest.
+      uses: arvsrao/googletest-action@master
+
+# I need to compile the files
+# then run the tests


### PR DESCRIPTION
Adding GitHub Actions is helpful for both the students and the TAs. I had trouble with the GoogleTest library when I tried this a few years ago, but it appears that there is now a [GoogleTest action](https://github.com/arvsrao/googletest-action) that I'm hoping will help me get all this to work in a reasonable way. 

Closes #3 (Setup GitHub Actions)